### PR TITLE
Updates suit-utils to 0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 === HEAD
 
+=== 0.3.1 (April 5, 2014)
+
+* Update 'suit-utils' to 0.8.0.
+
 === 0.3.0 (November 20, 2013)
 
 * Update 'suit-base' to 0.3.0.

--- a/bower.json
+++ b/bower.json
@@ -1,10 +1,10 @@
 {
   "name": "suit",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "author": "Nicolas Gallagher",
   "dependencies": {
     "suit-base": "~0.3.0",
-    "suit-utils": "~0.7.1",
+    "suit-utils": "~0.8.0",
     "suit-arrange": "~0.2.0",
     "suit-button": "~3.0.0",
     "suit-button-group": "~2.0.1",

--- a/component.json
+++ b/component.json
@@ -4,7 +4,7 @@
   "version": "0.3.0",
   "dependencies": {
     "suitcss/base": "0.3.0",
-    "suitcss/utils": "0.7.1",
+    "suitcss/utils": "0.8.0",
     "suitcss/arrange": "0.2.0",
     "suitcss/button": "v3.0.0",
     "suitcss/button-group": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "suit",
   "private": true,
-  "version": "0.3.0",
+  "version": "0.3.1",
   "devDependencies": {
     "component": "*"
   }


### PR DESCRIPTION
I was getting an error when running `bower install suit`.

``` bash
bower suit-utils-space#~0.1.2         
ECMDERR Failed to execute "git ls-remote --tags --heads git://github.com/suitcss/utils-space.git", exit code of #128
```
- Update 'suit-utils' to 0.8.0
- 'suit-utils' 0.7.1 has 'suit-utils-space' as a dependency, but that
  repository doesn't exist anymore.

_NOTE: Not sure if updating suit-utils to 0.8.0 causes any other problem that I'm might not aware of._
