### PR TITLE
go package manager-less

### DIFF
--- a/index.css
+++ b/index.css
@@ -1,0 +1,9 @@
+
+@import '//cdn.rawgit.com/suitcss/base/0.5.0/base.css';
+/* @import '//cdn.rawgit.com/suitcss/utils/0.8.0/index.css'; */
+@import '//cdn.rawgit.com/suitcss/components-arrange/0.3.0/arrange.css';
+@import '//cdn.rawgit.com/suitcss/components-button/3.1.0/button.css';
+@import '//cdn.rawgit.com/suitcss/components-button-group/2.2.0/button-group.css';
+@import '//cdn.rawgit.com/suitcss/components-button-group/2.2.0/button-group.plugin.css';
+@import '//cdn.rawgit.com/suitcss/components-flex-embed/1.5.1/flex-embed.css';
+@import '//cdn.rawgit.com/suitcss/components-grid/1.3.0/grid.css';


### PR DESCRIPTION
i'm pretty much giving up on all the package managers. my current philosophy is to only use standards and expect package managers and build processes to be able to use them.

for example, this creates an `index.css` file so that ideally, in development, all i'd have to do to get started with `suit` is to add the following tag:

``` html
<link rel="stylesheet" href="//cdn.rawgit.com/suitcss/suit/0.4.0/index.css">
```

then use some sort of package manager or build system to bundle everything together.

this is kind of what https://normalize.github.io is, except it allows semver ranges as well as supports other remotes. `nlz-build(1)` will download and concatenate all these imported styles. normalize also supports rawgit URLs.

note: this doesn't work right now because you'll have to do it with every component
