### PR TITLE
Fix rogue `descendant` in naming conventions doc

### DIFF
--- a/doc/naming-conventions.md
+++ b/doc/naming-conventions.md
@@ -13,7 +13,7 @@ The primary architectural division is between **[utilities](utilities.md)** and
 * [u-utilityName](#u-utilityName)
 * [ComponentName](#ComponentName)
 * [ComponentName--modifierName](#ComponentName--modifierName)
-* [ComponentName-descendantName](#ComponentName-descendantName)
+* [ComponentName-descendentName](#ComponentName-descendentName)
 * [ComponentName.is-stateOfComponent](#is-stateOfComponent)
 
 ## [Utilities](utilities.md)


### PR DESCRIPTION
`descendant` to `descendent`: consistency, fix anchor.