### PR TITLE
Update STYLE.md to allow function arguments to be split across multiple lines 

### DIFF
--- a/doc/STYLE.md
+++ b/doc/STYLE.md
@@ -309,15 +309,19 @@ before the closing brace.
 .selector-3 { width: 30%; }
 ```
 
-Long, comma-separated property values - such as collections of gradients or
-shadows - can be arranged across multiple lines in an effort to improve
-readability and produce more useful diffs.
+Long, comma-separated property values - such as collections of shadows - or
+function arguments - such as those for gradients - can be arranged across
+multiple lines in an effort to improve readability and produce more useful diffs.
 
 ```css
 .selector {
-  background-image:
-    linear-gradient(#fff, #ccc),
-    linear-gradient(#f3c, #4ec);
+  background-image: repeating-linear-gradient(
+    -45deg,
+    transparent,
+    transparent 25px,
+    rgba(255, 255, 255, 1) 25px,
+    rgba(255, 255, 255, 1) 50px
+  );
   box-shadow:
     1px 1px 1px #000,
     2px 2px 1px 1px #ccc inset;


### PR DESCRIPTION
Hello,

This small PR adds long, comma separated function arguments to the list of things that can be separated across multiple lines if it aids in the readability of the code e.g. 

```css
.selector {
  background-image: repeating-linear-gradient(
    -45deg,
    transparent,
    transparent 25px,
    rgba(255, 255, 255, 1) 25px,
    rgba(255, 255, 255, 1) 50px
  );
}
```

We've added a couple of rules to `stylelint` recently that should cover all the things listed in the "Exceptions and slight deviations" section of STYLE.md. 

Once this PR is decided upon I'll update `stylelint-config-suitcss` to reflect this and get version `1.0.0` out. 

Please don’t hesitate to give me a holler if you stumble into any issues with the config when you get around to #122, as I’ll be happy to help :)
