### PR TITLE
Correct style of multi-line declaration

### DIFF
--- a/doc/STYLE.md
+++ b/doc/STYLE.md
@@ -315,13 +315,14 @@ multiple lines in an effort to improve readability and produce more useful diffs
 
 ```css
 .selector {
-  background-image: repeating-linear-gradient(
-    -45deg,
-    transparent,
-    transparent 25px,
-    rgba(255, 255, 255, 1) 25px,
-    rgba(255, 255, 255, 1) 50px
-  );
+  background-image:
+    repeating-linear-gradient(
+      -45deg,
+      transparent,
+      transparent 25px,
+      rgba(255, 255, 255, 1) 25px,
+      rgba(255, 255, 255, 1) 50px
+    );
   box-shadow:
     1px 1px 1px #000,
     2px 2px 1px 1px #ccc inset;


### PR DESCRIPTION
Oops, my bad. I got the style of the multi-line declaration wrong in my last PR.

I only realised my mistake while testing the upcoming release of `stylelint-config-suitcss`.

The `repeating-linear-gradient` declaration should match the style of the `box-shadow`one i.e. with a newline after the colon:

```css
.selector {
  background-image:
    repeating-linear-gradient(
      -45deg,
      transparent,
      transparent 25px,
      rgba(255, 255, 255, 1) 25px,
      rgba(255, 255, 255, 1) 50px
    );
  box-shadow:
    1px 1px 1px #000,
    2px 2px 1px 1px #ccc inset;
}
```

Sorry about that...