### PR TITLE
Clarify component syntax

### DIFF
--- a/doc/naming-conventions.md
+++ b/doc/naming-conventions.md
@@ -51,7 +51,7 @@ breakpoints.
 
 The CSS responsible for component-specific styling.
 
-Syntax: `[<namespace>-]<ComponentName>[--modifierName|-descendentName]`
+Syntax: `[<namespace>-]<ComponentName>[-descendentName][--modifierName]`
 
 This has several benefits when reading and writing HTML and CSS:
 


### PR DESCRIPTION
As `[]` just describes an option `<ComponentName>[--modifierName|-descendentName]` would only allow classes like `.Component--modifier { ... }` or `.Component-descendent { ... }`. 
Classes like `.FlexEmbed-ratio--16by9` would not be allowed here.

