### PR TITLE
Variable naming convention

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -9,6 +9,7 @@
   * [ComponentName--modifierName](naming-conventions.md#ComponentName--modifierName)
   * [ComponentName-descendentName](naming-conventions.md#ComponentName-descendentName)
   * [ComponentName.is-stateOfComponent](naming-conventions.md#is-stateOfComponent)
+  * [Variables](naming-conventions.md#variables)
 * [Utilities](utilities.md)
 * [Components](components.md)
 * [API](api.md)

--- a/doc/naming-conventions.md
+++ b/doc/naming-conventions.md
@@ -172,7 +172,7 @@ Custom properties are global. Components should not expose the internal structur
 
 ### Theme Variables
 
-Non-component variables must be written in camel case. For shared use, they should be authored in a `theme.css` file.
+Non-component variables must be written in camel case. For shared use, they should be authored in [a `theme.css`](https://github.com/suitcss/theme) file.
 
 ```css
 :root {

--- a/doc/naming-conventions.md
+++ b/doc/naming-conventions.md
@@ -15,6 +15,7 @@ The primary architectural division is between **[utilities](utilities.md)** and
 * [ComponentName--modifierName](#ComponentName--modifierName)
 * [ComponentName-descendentName](#ComponentName-descendentName)
 * [ComponentName.is-stateOfComponent](#is-stateOfComponent)
+* [Variables](variables.md)
 
 ## [Utilities](utilities.md)
 
@@ -150,4 +151,37 @@ the component).
 <article class="Tweet is-expanded">
   …
 </article>
+```
+## [Variables](variables.md)
+
+Syntax: `--ComponentName[-descendant|--modifier][-onState]-(cssProperty|variableName)`
+
+### Component Variables
+
+Custom properties are global. Components should not expose the internal structure. Variables used in components should have a flat structure after their namespace.
+
+```css
+:root {
+  --ComponentName-backgroundColor
+  --ComponentName-descendant-backgroundColor
+  --ComponentName--modifier-backgroundColor
+  --ComponentName-onHover-backgroundColor
+  --ComponentName-descendant-onHover-backgroundColor
+}
+```
+
+### Theme Variables
+
+Non-component variables must be written in camel case. For shared use, they should be authored in a `theme.css` file.
+
+```css
+:root {
+  --fontSize: 16px;
+  --fontFamily: sans-serif;
+  --lineHeight: 1.5;
+
+  --spaceSm: 16px;
+  --spaceMd: 32px;
+  --spaceLg: 64px;
+}
 ```

--- a/doc/naming-conventions.md
+++ b/doc/naming-conventions.md
@@ -15,7 +15,7 @@ The primary architectural division is between **[utilities](utilities.md)** and
 * [ComponentName--modifierName](#ComponentName--modifierName)
 * [ComponentName-descendentName](#ComponentName-descendentName)
 * [ComponentName.is-stateOfComponent](#is-stateOfComponent)
-* [Variables](variables.md)
+* [Variables](#variables)
 
 ## [Utilities](utilities.md)
 


### PR DESCRIPTION
This is addressing the docs addition for [Issue #91](https://github.com/suitcss/suit/issues/91). I did not implement for `postcss-bem-linter`.